### PR TITLE
Solve build failure due to outdated jdiameter release and S6a compilation error

### DIFF
--- a/resources/diameter-base/pom.xml
+++ b/resources/diameter-base/pom.xml
@@ -26,8 +26,8 @@
 
 	<properties>
 		<!-- Mobicents Diameter Components Versions -->
-		<restcomm.diameter.jdiameter.version>1.7.0.77</restcomm.diameter.jdiameter.version>
-		<restcomm.diameter.mux.version>1.7.0.77</restcomm.diameter.mux.version>
+		<restcomm.diameter.jdiameter.version>1.7.0.139</restcomm.diameter.jdiameter.version>
+		<restcomm.diameter.mux.version>1.7.0.139</restcomm.diameter.mux.version>
 		<restcomm.slee.version>2.8.26</restcomm.slee.version>
 		<!-- Documentation Related Properties -->
 		<docs.profile>restcomm</docs.profile>

--- a/resources/diameter-s6a/events/pom.xml
+++ b/resources/diameter-s6a/events/pom.xml
@@ -17,6 +17,11 @@
 			<artifactId>restcomm-slee-ra-diameter-base-common-events</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-	</dependencies>
+    <dependency>
+      <groupId>bcel</groupId>
+      <artifactId>bcel</artifactId>
+      <version>5.1</version>
+    </dependency>
+  </dependencies>
 
 </project>

--- a/resources/diameter-s6a/events/pom.xml
+++ b/resources/diameter-s6a/events/pom.xml
@@ -17,11 +17,6 @@
 			<artifactId>restcomm-slee-ra-diameter-base-common-events</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-    <dependency>
-      <groupId>bcel</groupId>
-      <artifactId>bcel</artifactId>
-      <version>5.1</version>
-    </dependency>
   </dependencies>
 
 </project>

--- a/resources/diameter-s6a/events/pom.xml
+++ b/resources/diameter-s6a/events/pom.xml
@@ -17,6 +17,6 @@
 			<artifactId>restcomm-slee-ra-diameter-base-common-events</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-  </dependencies>
+	</dependencies>
 
 </project>

--- a/resources/diameter-s6a/events/src/main/java/net/java/slee/resource/diameter/s6a/events/avp/PLMNClient.java
+++ b/resources/diameter-s6a/events/src/main/java/net/java/slee/resource/diameter/s6a/events/avp/PLMNClient.java
@@ -23,7 +23,7 @@
 package net.java.slee.resource.diameter.s6a.events.avp;
 
 import net.java.slee.resource.diameter.base.events.avp.Enumerated;
-import org.apache.bcel.generic.BREAKPOINT;
+
 
 import java.io.Serializable;
 


### PR DESCRIPTION
Update to latest jdiameter release including S13 interface and prevent compilation errors in S6a interface.
Attached build success result product of this changes.
[build_success.txt](https://github.com/RestComm/jain-slee.diameter/files/859782/build_success.txt)
