### PR TITLE
Fixes RestComm/jain-slee.diameter#37 the start activity removal timer

### DIFF
--- a/resources/diameter-base/common/ra/src/main/java/org/mobicents/slee/resource/diameter/LocalDiameterActivityManagement.java
+++ b/resources/diameter-base/common/ra/src/main/java/org/mobicents/slee/resource/diameter/LocalDiameterActivityManagement.java
@@ -84,7 +84,7 @@ public class LocalDiameterActivityManagement implements DiameterActivityManageme
    * (org.mobicents.slee.resource.diameter.base.DiameterActivityHandle)
    */
   public void startActivityRemoveTimer(DiameterActivityHandle handle) {
-    if(this.activities.contains(handle)) {
+    if(this.activities.containsKey(handle)) {
       ActivityRemoveTimerTask task = new ActivityRemoveTimerTask(handle);
       this.removeMap.put(handle, task);
       this.timer.schedule(new ActivityRemoveTimerTask(handle), delay);


### PR DESCRIPTION
Scheduled diameter activities deletion does not work properly, startActivityRemoveTimer method should use containsKey map method instead of contains